### PR TITLE
Removes the hard coded xml ID issue #40 in Chp 3.3

### DIFF
--- a/source/ch3-malware.ptx
+++ b/source/ch3-malware.ptx
@@ -74,7 +74,7 @@
 					</p>
 					<!--</div attr= class="paragraph">-->
 					<!-- div attr= class="sect3"-->
-					<paragraphs xml:id="worms-viruses-and-trojans-_worms_viruses_and_trojans">
+					<paragraphs xml:id="worms-viruses-and-trojans">
 						<title>3.3.1. Worms, Viruses, and Trojans</title>
 						<!-- div attr= class="paragraph"-->
 						<p>
@@ -83,12 +83,11 @@
 						<!--</div attr= class="paragraph">-->
 						<!-- div attr= class="exampleblock"-->
 						<!-- div attr= class="title"-->
-						<p>
+						
+					<p>
 						Example 3. Stuxnet
 					</p>
-						<!--</div attr= class="title">-->
-						<!-- div attr= class="content"-->
-						<!-- div attr= class="paragraph"-->
+						
 						<p>
 						Stuxnet was a 2010 worm that specifically targeted Iranian nuclear facilities. The worm used an unprecedented four zero-day attacks and was designed to spread via USB flash drives and Remote Procedure Calls (RPCs). In this way it didn’t just rely on networks to propagate. Ultimately Stuxnet’s payload targeted the code used to program PLC devices that control motors and make them spin too fast, destroying the centrifuges. Stuxnet also employed an impressive rootkit to cover its tracks. Given the level of sophistication Stuxnet is believed to have been developed by the US and Israel.
 					</p>
@@ -102,19 +101,15 @@
 						<!--</div attr= class="paragraph">-->
 						<!-- div attr= class="exampleblock"-->
 						<!-- div attr= class="title"-->
+						
 						<p>
-						Example 4. Concept Virus
-					</p>
-						<!--</div attr= class="title">-->
-						<!-- div attr= class="content"-->
-						<!-- div attr= class="paragraph"-->
+						Example 4. Concept
+						</p>
 						<p>
 						The Concept virus was the first example of a Microsoft Word macro virus. The virus hid itself inside Microsoft Word files and used Word’s embedded macro language to perform its replication tasks. Viruses were later created for Excel and other programs that had sufficiently sophisticated yet ultimately insecure internal scripting languages.
 					</p>
-						<!--</div attr= class="paragraph">-->
-						<!--</div attr= class="content">-->
-						<!--</div attr= class="exampleblock">-->
-						<!-- div attr= class="paragraph"-->
+
+
 						<p>
 						A trojan is a form of malware that disguises itself as legitimate software. It does not have to rely on a software exploit as much as it exploits users into installing, running, or giving extra privileges to the malicious code. Trojans are the most popular kind of malware as they can be used as an attack vector for many other payloads. The name comes from Greek mythology, where a Trojan horse was disguised as a gift and given to a besieged town. Within the large horse were secret troops who came out in the middle of the night and opened the town gates.
 					</p>
@@ -136,7 +131,7 @@
 						<!--</div attr= class="sect3">-->
 						<!-- div attr= class="sect3"-->
 					</paragraphs>
-					<paragraphs xml:id="ransomware-_ransomware">
+					<paragraphs xml:id="ransomware">
 						<title>3.3.2. Ransomware</title>
 						<!-- div attr= class="imageblock right"-->
 						<!-- div attr= class="content"-->
@@ -165,7 +160,7 @@
 						<!--</div attr= class="sect3">-->
 						<!-- div attr= class="sect3"-->
 					</paragraphs>
-					<paragraphs xml:id="spyware-_spyware">
+					<paragraphs xml:id="spyware">
 						<title>3.3.3. Spyware</title>
 						<!-- div attr= class="paragraph"-->
 						<p>
@@ -204,7 +199,7 @@
 						<!--</div attr= class="sect3">-->
 						<!-- div attr= class="sect3"-->
 					</paragraphs>
-					<paragraphs xml:id="cryptojacking-_cryptojacking">
+					<paragraphs xml:id="cryptojacking">
 						<title>3.3.4. Cryptojacking</title>
 						<!-- div attr= class="paragraph"-->
 						<p>
@@ -219,7 +214,7 @@
 						<!--</div attr= class="sect3">-->
 						<!-- div attr= class="sect3"-->
 					</paragraphs>
-					<paragraphs xml:id="rootkit-_rootkit">
+					<paragraphs xml:id="rootkit">
 						<title>3.3.5. Rootkit</title>
 						<!-- div attr= class="openblock float-group"-->
 						<!-- div attr= class="content"-->
@@ -288,7 +283,7 @@
 						<!--</div attr= class="sect3">-->
 						<!-- div attr= class="sect3"-->
 					</paragraphs>
-					<paragraphs xml:id="botnet-_botnet">
+					<paragraphs xml:id="botnet">
 						<title>3.3.6. Botnet</title>
 						<!-- div attr= class="paragraph"-->
 						<p>
@@ -303,7 +298,7 @@
 						<!--</div attr= class="sect3">-->
 						<!-- div attr= class="sect3"-->
 					</paragraphs>
-					<paragraphs xml:id="rat-_rat">
+					<paragraphs xml:id="rat">
 						<title>3.3.7. RAT</title>
 						<!-- div attr= class="paragraph"-->
 						<p>
@@ -313,7 +308,7 @@
 						<!--</div attr= class="sect3">-->
 						<!-- div attr= class="sect3"-->
 					</paragraphs>
-					<paragraphs xml:id="adware-potentially-unwanted-programs-pup-_adware_potentially_unwanted_programs_pup">
+					<paragraphs xml:id="adware-potentially-unwanted-programs-pup">
 						<title>3.3.8. Adware / Potentially Unwanted Programs (PUP)</title>
 						<!-- div attr= class="paragraph"-->
 						<p>

--- a/source/ch3-malware.ptx
+++ b/source/ch3-malware.ptx
@@ -75,7 +75,7 @@
 					<!--</div attr= class="paragraph">-->
 					<!-- div attr= class="sect3"-->
 					<paragraphs xml:id="worms-viruses-and-trojans-_worms_viruses_and_trojans">
-						<title>3.3.1. Worms, Viruses, and Trojans {#_worms_viruses_and_trojans}</title>
+						<title>3.3.1. Worms, Viruses, and Trojans</title>
 						<!-- div attr= class="paragraph"-->
 						<p>
 						Worms are self-propagating programs that spread without user interaction. Their code is typically stored within an independent object, such as a hidden executable file. Worms often do not severely damage their host, as they are concerned with rapid, exponential spreading.
@@ -137,7 +137,7 @@
 						<!-- div attr= class="sect3"-->
 					</paragraphs>
 					<paragraphs xml:id="ransomware-_ransomware">
-						<title>3.3.2. Ransomware {#_ransomware}</title>
+						<title>3.3.2. Ransomware</title>
 						<!-- div attr= class="imageblock right"-->
 						<!-- div attr= class="content"-->
 						<figure>
@@ -166,7 +166,7 @@
 						<!-- div attr= class="sect3"-->
 					</paragraphs>
 					<paragraphs xml:id="spyware-_spyware">
-						<title>3.3.3. Spyware {#_spyware}</title>
+						<title>3.3.3. Spyware</title>
 						<!-- div attr= class="paragraph"-->
 						<p>
 						Malware specifically designed for espionage/data theft is known as spyware. Like ransomware, spyware can also have a monetary payoff for the threat actor. Actors may use extortion to demand payment or the data will be 
@@ -205,7 +205,7 @@
 						<!-- div attr= class="sect3"-->
 					</paragraphs>
 					<paragraphs xml:id="cryptojacking-_cryptojacking">
-						<title>3.3.4. Cryptojacking {#_cryptojacking}</title>
+						<title>3.3.4. Cryptojacking</title>
 						<!-- div attr= class="paragraph"-->
 						<p>
 						Crypto currencies utilizing proof-of-work algorithms have made it easier than ever for programs to convert processor cycles into money. Certain types of malware capitalize on this by mining cryptocurrency in the background on a users machine. This theft of power and resources can result income for the malware distributor when the funds from mining are deposited into their online wallet.
@@ -220,7 +220,7 @@
 						<!-- div attr= class="sect3"-->
 					</paragraphs>
 					<paragraphs xml:id="rootkit-_rootkit">
-						<title>3.3.5. Rootkit {#_rootkit}</title>
+						<title>3.3.5. Rootkit</title>
 						<!-- div attr= class="openblock float-group"-->
 						<!-- div attr= class="content"-->
 						<!-- div attr= class="imageblock left"-->
@@ -289,7 +289,7 @@
 						<!-- div attr= class="sect3"-->
 					</paragraphs>
 					<paragraphs xml:id="botnet-_botnet">
-						<title>3.3.6. Botnet {#_botnet}</title>
+						<title>3.3.6. Botnet</title>
 						<!-- div attr= class="paragraph"-->
 						<p>
 						A botnet is a network of exploited hosts controlled by a single party. These hosts may be desktop computers, servers, or even internet of things (IoT) devices. Botnets are often used in large-scale distributed denial of service (DDoS) attacks where the nature of the attack is to have many machines flooding a single machine with traffic. Botnets may also be used to send spam emails as their access to SMTP email relay may vary depending on their internet service provider (ISP).
@@ -304,7 +304,7 @@
 						<!-- div attr= class="sect3"-->
 					</paragraphs>
 					<paragraphs xml:id="rat-_rat">
-						<title>3.3.7. RAT {#_rat}</title>
+						<title>3.3.7. RAT</title>
 						<!-- div attr= class="paragraph"-->
 						<p>
 						RAT stands for Remote Access Trojan an it is used to gain full access and control of a remote target. The malware distributor can browse the files on a computer, send keystrokes and mouse movements, view the screen, and/or monitor the input from the microphone and camera. RATs often actively bypass security controls and as such they may be difficult to detect.
@@ -314,7 +314,7 @@
 						<!-- div attr= class="sect3"-->
 					</paragraphs>
 					<paragraphs xml:id="adware-potentially-unwanted-programs-pup-_adware_potentially_unwanted_programs_pup">
-						<title>3.3.8. Adware / Potentially Unwanted Programs (PUP) {#_adware_potentially_unwanted_programs_pup}</title>
+						<title>3.3.8. Adware / Potentially Unwanted Programs (PUP)</title>
 						<!-- div attr= class="paragraph"-->
 						<p>
 						Adware is malware that is designed to track user behavior and deliver unwanted, sometimes intrusive, tailored ads. Adware may slow down a system and/or add ad walls to sites. This type of malware often targets a users web browser.

--- a/source/ch3-malware.ptx
+++ b/source/ch3-malware.ptx
@@ -103,7 +103,7 @@
 						<!-- div attr= class="title"-->
 						
 						<p>
-						Example 4. Concept
+						Example 4. Concept Virus
 						</p>
 						<p>
 						The Concept virus was the first example of a Microsoft Word macro virus. The virus hid itself inside Microsoft Word files and used Word’s embedded macro language to perform its replication tasks. Viruses were later created for Excel and other programs that had sufficiently sophisticated yet ultimately insecure internal scripting languages.


### PR DESCRIPTION
# Description
I went through Chapter 3.3 and removed the hardcoded XML for all titles. Also, there was a typo for the actual XML ID where the ID was repeated twice; those have been removed, as Dr Jan asked.

Also removed some of the unnecessary comments.

This issue was initially more significant and dealt with the examples, so I was working on that on the same branch, which is why there are edits to the examples in the file changes. Don't worry; they should be back to normal, with no merge conflict.

## Related Issue
issue #40 

## How Has This Been Tested?
Locally built and run
Dr. Jan approved these changes.
