### PR TITLE
Changes the tags and formatting to show missing information Fixes issue #39

### DIFF
--- a/source/ch3-malware.ptx
+++ b/source/ch3-malware.ptx
@@ -207,47 +207,42 @@
             </subsection>
     </section>
 
-				<section xml:id="indicators-of-compromise-_indicators_of_compromise">
-					<title>3.4. Indicators of Compromise {#_indicators_of_compromise}</title>
-					<!-- div attr= class="paragraph"-->
+				<section xml:id="indicators-of-compromise">
+					<title> Indicators of Compromise</title>
+					<idx>indicator of compromise (IoC)</idx>
 					<p>
-					An 
-						<em>indicator of compromise (IoC)</em> is an artifact with high confidence the indicates an intrusion. It is a way to tell if a machine has been a victim of malware. IoCs are publicly communicated by security professionals in an effort to help mitigate the effects of malware.
+						An 
+						<term>indicator of compromise (IoC)</term> is an artifact with high confidence the indicates an intrusion. It is a way to tell if a machine has been a victim of malware. IoCs are publicly communicated by security professionals in an effort to help mitigate the effects of malware.
 				
 					</p>
-					<!--</div attr= class="paragraph">-->
-					<!-- div attr= class="dlist"-->
-					<!-- div attr= class="title"-->
+
+					<example xml:id="example-iocs">
+						<title> IoCs</title>
+					<idx>hash</idx><idx>ip address</idx><idx>url</idx><idx>domain</idx><idx>virus definition/signature</idx>
 					<p>
-					Common IoC Types
-				</p>
-					<!--</div attr= class="title">-->
-					<dl>
-						<dt>Hash</dt>
-						<dd>
-							<p>
-					A hash of files that are known to be malicious. This can help in identifying trojans and worms.
-				</p>
-						</dd>
-						<dt>IP addresses</dt>
-						<dd>
-							<p>
-					Tracking the IP addresses which malware connects to can be used to determine if a machine is infected.
-				</p>
-						</dd>
-						<dt>URLs/Domains</dt>
-						<dd>
-							<p>
-					Tracking the URLs or domains that malware uses can also be used to determine if a machine is infected.
-				</p>
-						</dd>
-						<dt>Virus definition/signature</dt>
-						<dd>
-							<p>
-					Executables and other files can be scanned for specific sequences of bytes which are unique to a particular virus. In this way even if the malware is hiding within another file, it can still be detected.
-				</p>
-						</dd>
-					</dl>
+						Common IoC Types
+					</p>
+					<p>
+						<term>Hash</term>
+					</p>		
+					<p>
+						A hash of files that are known to be malicious. This can help in identifying trojans and worms.
+					</p>
+						<p><term>IP addresses</term></p>
+					<p>
+						Tracking the IP addresses which malware connects to can be used to determine if a machine is infected.
+					</p>
+						<p><term> URLs/Domains</term></p>
+						
+					<p>
+						Tracking the URLs or domains that malware uses can also be used to determine if a machine is infected.
+					</p>
+						
+						<p><term>Virus definition/signature</term></p>
+					<p>
+						Executables and other files can be scanned for specific sequences of bytes which are unique to a particular virus. In this way even if the malware is hiding within another file, it can still be detected.
+					</p>
+					</example>
 					<!--</div attr= class="dlist">-->
 					<!--</div attr= class="sect2">-->
 					<!-- div attr= class="sect2"-->

--- a/source/ch3-malware.ptx
+++ b/source/ch3-malware.ptx
@@ -209,43 +209,28 @@
 
 				<section xml:id="indicators-of-compromise">
 					<title> Indicators of Compromise</title>
-					<idx>indicator of compromise (IoC)</idx>
 					<p>
+						<idx>indicators of compromise</idx>
+						<idx>IoC</idx>
 						An 
 						<term>indicator of compromise (IoC)</term> is an artifact with high confidence the indicates an intrusion. It is a way to tell if a machine has been a victim of malware. IoCs are publicly communicated by security professionals in an effort to help mitigate the effects of malware.
 				
 					</p>
 
-					<example xml:id="example-iocs">
+					<paragraphs xml:id="example-iocs">
 						<title> IoCs</title>
-					<idx>hash</idx><idx>ip address</idx><idx>url</idx><idx>domain</idx><idx>virus definition/signature</idx>
 					<p>
 						Common IoC Types
 					</p>
-					<p>
-						<term>Hash</term>
-					</p>		
-					<p>
-						A hash of files that are known to be malicious. This can help in identifying trojans and worms.
-					</p>
-						<p><term>IP addresses</term></p>
-					<p>
-						Tracking the IP addresses which malware connects to can be used to determine if a machine is infected.
-					</p>
-						<p><term> URLs/Domains</term></p>
-						
-					<p>
-						Tracking the URLs or domains that malware uses can also be used to determine if a machine is infected.
-					</p>
-						
-						<p><term>Virus definition/signature</term></p>
-					<p>
-						Executables and other files can be scanned for specific sequences of bytes which are unique to a particular virus. In this way even if the malware is hiding within another file, it can still be detected.
-					</p>
-					</example>
-					<!--</div attr= class="dlist">-->
-					<!--</div attr= class="sect2">-->
-					<!-- div attr= class="sect2"-->
+				</paragraphs>		
+					<p><idx>hash</idx>A <term>Hash</term>: of files that are known to be malicious. This can help in identifying trojans and worms.</p>
+					
+					<p><idx>ip address</idx><term>IP addresses</term>:Tracking the IP addresses which malware connects to can be used to determine if a machine is infected.</p>		
+					
+					<p><idx>url/domain</idx><term> URLs/Domains</term>:Tracking the URLs or domains that malware uses can also be used to determine if a machine is infected.</p>
+					
+					<p><idx>virus definition/signature</idx><term>Virus definition/signature</term>:Executables and other files can be scanned for specific sequences of bytes which are unique to a particular virus. In this way even if the malware is hiding within another file, it can still be detected.</p>
+
 				</section>
 				<section xml:id="delivery-of-malware-_delivery_of_malware">
 					<title>3.5. Delivery of Malware {#_delivery_of_malware}</title>

--- a/source/ch3-malware.ptx
+++ b/source/ch3-malware.ptx
@@ -219,7 +219,7 @@
 				
 					</p>
 
-					<paragraphs xml:id="example-iocs">
+					<paragraphs xml:id="common-IoCs-types">
 						<title> IoCs</title>
 					<p>
 						Common IoC Types


### PR DESCRIPTION
# Description
Adds the hidden information that was in `<dl>` and `<dd>` tags. Added the relevant terms to the index. Fixed the indentation and repetition of XML IDs.

3.4 should be done entirely.

## Related Issue
#43 #21 Fixes #39 

## How Has This Been Tested?
Built and ran locally 
Reviewed by @FlashEb & @coco3427 