### PR TITLE
Removed or moved captions from images to clean up the descriptions/ac…

### DIFF
--- a/source/ch1-introduction.ptx
+++ b/source/ch1-introduction.ptx
@@ -5,15 +5,16 @@
 	<section xml:id="managing-risk">
 		<title>Managing Risk</title>
         <figure>
-            <caption>
-                <url href="https://commons.wikimedia.org/wiki/File:Database-locked.svg">RRZEicons</url>, 
+            <caption></caption>
+            <image source="db-locked.png" width="40%" decorative="yes"/>
+		</figure>
+		<p>
+			    <url href="https://commons.wikimedia.org/wiki/File:Database-locked.svg">RRZEicons</url>, 
                         
                 <url href="https://creativecommons.org/licenses/by-sa/3.0">CC BY-SA 3.0</url>, 
                 
                 <em>via Wikimedia Commons</em>
-            </caption>
-            <image source="db-locked.png" width="40%" decorative="yes"/>
-		</figure>
+		</p>
 		<p>
 			<idx>information security</idx>
 			<idx>infosec</idx>
@@ -78,7 +79,7 @@
 		<paragraphs xml:id="aaa">
 			<title>AAA </title>
             <figure xml:id="aaa-fig">
-                <caption>AAA Conceptual Diagram</caption>
+                <caption></caption>
                 <image source="aaa.svg" width="40%">
                     <shortdescription>Diagram illustrating AAA concepts: Authentication, Authorization, and Accounting.</shortdescription>
                     <description>
@@ -195,7 +196,7 @@
 		</p>
 		<p></p>
 		<figure>
-			<caption>Hat Scale</caption>
+			<caption></caption>
 			<image source="hats.png" width="100%">
                 <shortdescription>Alignment chart classifying hacker types (White, Black, Gray Hat) on Legal/Illegal and Malicious/Benevolent axes.</shortdescription>
                 <description>
@@ -235,11 +236,12 @@
 	<section xml:id="threat-actors">
         <title>Threat Actors</title>
             <figure xml:id="guy_fawkes_mask">
-                <caption>
-			<url href="https://en.wikipedia.org/wiki/Guy_Fawkes_mask#Anonymous" />
-					</caption>
+                <caption></caption>
                     <image source="anonymous.svg" width="40%" decorative="yes"/>
-				</figure>		
+				</figure>
+				<p>
+				<url href="https://en.wikipedia.org/wiki/Guy_Fawkes_mask#Anonymous" />
+				</p>
 		<p>
 			
 					To better be able to manage the risks of a data breach, it helps to be able to identify/understand the attacker or threat actor involved. Just as there are many reasons an actor may attempt to gain unauthorized access there are also many groups of threat actors.


### PR DESCRIPTION
…cessibility fixes issue #104
Fixes issue #104 
<!--- Provide a general summary of your changes in the Title above -->
Removes or moves captions to clean up descriptions and make it more uniform across the book.
# Description
<!--- Describe your changes in detail -->
I removed or moved captions into a paragraph below the image if it had a url. The descriptions had enough information to warrant such a move.
## Related Issue
<!--- This project prefers pull requests related to open issues -->
<!--- If suggesting a change, please discuss it in an issue first -->
<!--- Please link to the issue here: -->
This fixes issue #104 
## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
I ran a local build, tested urls, and was approved by @Austing767 