### PR TITLE
Rewrote line, fixes issue #99

### DIFF
--- a/source/ch10-virtualization.ptx
+++ b/source/ch10-virtualization.ptx
@@ -194,7 +194,7 @@
 						
 						<li>
 							<p> <idx><h>cloud</h></idx>
-					<term>Cloud</term>: Is the cloud provider you are using secure? If they have are compromised everything within them is compromised. Can you trust this computing base?
+					<term>Cloud</term>: Is the cloud provider you are using secure? If they have been compromised everything within them is compromised. Can you trust this computing base?
 				</p>
 						</li>
 					</ul>


### PR DESCRIPTION
# Description
Changed the grammatical error of 

> have are compromised  

> have been compromised

This issue is best formatted for readability and context. I thought about putting have/are, but decided it was better to remove and replace are.

## Related Issue
Fixes issue #99 

## How Has This Been Tested?
Built and ran locally, @coco3427 helped me come up with a solution.
