### PR TITLE
Added a section on Docker to the command cheat sheet. 

### DIFF
--- a/source/ap-bash-cheatsheet.ptx
+++ b/source/ap-bash-cheatsheet.ptx
@@ -585,17 +585,42 @@ The <term>touch</term> command is commonly used for file creation. Its intended 
               <ul>
                 <li>
                   <p>
-                  e.g. <c>docker images</c> Shows all local images. 
+                  e.g. <c>docker run</c> runs containers.
                   </p>
                 </li>
                 <li>
                   <p>
-                  e.g. <c>docker ps</c> Shows all currently running containers. Adding the <c>-a</c> flag shows images that are stopped as well.
+                  e.g. <c>docker build</c> builds container images. 
+                  </p>
+                </li>
+                <li>
+                  <p>
+                  e.g. <c>docker images</c> shows all local images. 
+                  </p>
+                </li>
+                <li>
+                  <p>
+                  e.g. <c>docker ps</c> shows all currently running containers. Adding the <c>-a</c> flag shows images that are stopped as well.
                   </p>
                 </li>
                 <li>
                   <p>
                   e.g. <c>docker start &lt;container&gt;</c> and <c>docker stop &lt;container&gt;</c> start and stop containers. 
+                  </p>
+                </li>
+                <li>
+                  <p>
+                  e.g. <c>docker-compose up</c> starts multi-container applications.
+                  </p>
+                </li>
+                <li>
+                  <p>
+                  e.g. <c>docker-compose run</c> runs commands in containers. 
+                  </p>
+                </li>
+                <li>
+                  <p>
+                  e.g. <c>docker-compose down</c> stops containers. 
                   </p>
                 </li>
                 <li>


### PR DESCRIPTION
I was working on issue #165 and noticed there wasn't a Docker section in the commands cheat sheet. I added a section and a few common docker commands. Additionally, the title that reads "Key Security Programs Used in this Text." was changed to "Key Programs Used in this Text." to make this paragraph more broad and to reflect the fact that Docker isn't just a security program. This is an additional fix for issue #177.
