### PR TITLE
Fixes Issue #214: sudo missing

### DIFF
--- a/source/ch7-access-controls.ptx
+++ b/source/ch7-access-controls.ptx
@@ -735,7 +735,7 @@ drwxr-xr-x 2 carol carol 4096 Oct 28 01:28 carol</pre>
 					When a user is added to a UNIX system with the 
 						<c>useradd</c> command a group with their name is created. This allows us to pass a group to 
 						<c>chown</c> that only they will have access to. While this is a good start, others still have the ability to read and execute these directories, meaning 
-						<em>anyone</em> can view the contents. To prove this, lets assume the role of dave switching to the user dave by typing <c>su dave </c> and then do an 
+						<em>anyone</em> can view the contents. To prove this, lets assume the role of dave switching to the user dave by typing <c>sudo su dave </c> and then do an 
 						<c>ls</c> on each of the directories as follows:
 				
 					</p>


### PR DESCRIPTION
# Description
Adds sudo to the "su dave" command in 7.4.3

fixes #214 

Before:
<img width="883" height="423" alt="image" src="https://github.com/user-attachments/assets/fa49b0b1-cb86-4bea-80ad-da57ee51cb4d" />

After:
<img width="948" height="427" alt="image" src="https://github.com/user-attachments/assets/a988b3c4-ed2e-4839-9b45-3b8a1bd50127" />


## How Has This Been Tested?
Web build

Reviewed by Hope Michael
