### PR TITLE
fixed the incorrect link in 10.5.1 issue#218

### DIFF
--- a/source/ch10-virtualization.ptx
+++ b/source/ch10-virtualization.ptx
@@ -254,7 +254,7 @@ COPY index.php /var/www/html/index.php</pre>
 						Be sure to either stop or delete this codespace when you are done by clicking the "Stop" button or the "Delete" button in the Codespaces tab of your repository. 
 						</p>
 						<p>
-						Next, jump down to follow the lab directions in <xref ref="log4j-continue" />. 
+						Next, jump down to follow the lab directions in <xref ref="malicious-continue" />. 
 						</p>
 					</subsection>
 				<subsection xml:id="malicious-local">


### PR DESCRIPTION


# Description
Fixed the incorrect link that would have directed you to chapter 6.9.3. The new link now correctly directs you to chapter 10.5.3
fixes #218  

## How Has This Been Tested?
local build 
reviewed by Habiba, Din Din, Jarius 
