### PR TITLE
Fixed issue #226 where the command and control was duplicated

### DIFF
--- a/source/ch10-virtualization.ptx
+++ b/source/ch10-virtualization.ptx
@@ -254,7 +254,7 @@ COPY index.php /var/www/html/index.php</pre>
 						Be sure to either stop or delete this codespace when you are done by clicking the "Stop" button or the "Delete" button in the Codespaces tab of your repository. 
 						</p>
 						<p>
-						Next, jump down to follow the lab directions in <xref ref="log4j-continue" />. 
+						Next, jump down to follow the lab directions in <xref ref="malicious-continue" />. 
 						</p>
 					</subsection>
 				<subsection xml:id="malicious-local">

--- a/source/ch9-incident-response.ptx
+++ b/source/ch9-incident-response.ptx
@@ -530,7 +530,7 @@
 						<title>Command and Control</title>
 
 						<p>
-							<idx>Command and Control</idx>
+							<idx>command and control</idx>
 							<idx>C2</idx>
 							<idx>C&amp;C</idx>
 						<term>Command and Control</term> (<term>C2</term> or <term>C&amp;C</term>) refers to the process of setting up a channel between the compromised internal systems and an external system. This channel can be used to get data off the compromised machines and/or for putting malware on the machines. A C2 channel allows the operator to send interact with the compromised machines and even automate much of the work.


### PR DESCRIPTION
# Description
Command and control was mentioned twice in the index with different capitalization, fixed it by making it the same structure, lower-cased, mentioning two paragraphs. 

Before:
<img width="1120" height="816" alt="image" src="https://github.cohttps://github.com/pearcej/comp-sys-sec/commit/6defc7e23c010c6ccd1af70f68d2b1f4b8872f87m/user-attachments/assets/b01764a8-c5aa-4345-bc20-0a90c0333b95" />

After:
<img width="985" height="757" alt="image" src="https://github.com/user-attachments/assets/3136673e-5e47-4cf4-8946-0b005f783b0a" />

fixes #226 


## How Has This Been Tested?
Local build 

Reviewed by Din Din 

(The first commit (in chapter 10) is an accident, as I was troubleshooting Merci's problem; the only changes are in chapter 9) 